### PR TITLE
Fix ImportError (PY3 from cornice)

### DIFF
--- a/cornice_sphinx/__init__.py
+++ b/cornice_sphinx/__init__.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     pass
 
-from cornice.util import to_list, is_string, PY3
+from cornice.util import to_list, is_string
 from cornice.service import get_services, clear_services
 
 import docutils
@@ -23,6 +23,7 @@ from docutils.writers.html4css1 import Writer, HTMLTranslator
 from sphinx.util.docfields import DocFieldTransformer
 
 MODULES = {}
+PY3 = sys.version_info[0] == 3
 
 
 def convert_to_list(argument):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,7 +25,7 @@ class TestServiceDirective(TestCase):
 
         self.directive = ServiceDirective(
             'test', [], {}, [], 1, 1, 'test', param, 1)
-        self.directive.options['app'] = 'cornice.tests.ext.dummy'
+        self.directive.options['app'] = 'tests.dummy'
         self.directive.options['services'] = ['users', "thing_service"]
 
     def test_module_reload(self):

--- a/tests/dummy/__init__.py
+++ b/tests/dummy/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from pyramid.config import Configurator
+
+
+def main(global_config, **settings):
+    config = Configurator(settings=settings)
+
+    config.include('cornice')
+    config.include('tests.dummy.views.includeme')
+    return config.make_wsgi_app()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/dummy/views.py
+++ b/tests/dummy/views.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from collections import defaultdict
+from cornice import Service
+from cornice import resource
+
+_USERS = defaultdict(dict)
+
+
+class ThingImp(object):
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    def collection_get(self):
+        """Returns yay."""
+        return 'yay'
+
+
+def get_info(request):
+    """Returns the user data."""
+    username = request.matchdict['username']
+    return _USERS[username]
+
+
+def validate(request):
+    """Dummy validation."""
+    return request
+
+
+def includeme(config):
+    # FIXME this should also work in includeme
+    user_info = Service(name='users', path='/{username}/info',
+                        validators=('validate'))
+    user_info.add_view('get', get_info)
+    config.add_cornice_service(user_info)
+
+    resource.add_view(ThingImp.collection_get, permission='read')
+    thing_resource = resource.add_resource(
+        ThingImp, collection_path='/thing', path='/thing/{id}',
+        name='thing_service')
+    config.add_cornice_resource(thing_resource)


### PR DESCRIPTION
Fix ImportError "Cannot import name 'PY3'" because it was removed from
cornice and also created a dummy app to get the tests running again
(also was removed from cornice).