### PR TITLE
Add `docstring-replace` option to `cornice-autodoc` directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ The directive has the following options:
 - **service**: if you have only one name, then you can use `service` rather
   than `services`. **optional**
 - **ignore**: a comma separated list of services names to ignore. **optional**
+- **docstring-replace**: replace certain words in docstring. **optional**
 
   **module** or **app** are **mandatory**
 

--- a/cornice_sphinx/__init__.py
+++ b/cornice_sphinx/__init__.py
@@ -42,6 +42,14 @@ def convert_to_list_required(argument):
     return convert_to_list(argument)
 
 
+def from_json_to_dict(argument):
+    """Loads json data"""
+    if argument is None:
+        return {}
+    else:
+        return json.loads(argument)
+
+
 class ServiceDirective(Directive):
     """ Service directive.
 
@@ -56,6 +64,8 @@ class ServiceDirective(Directive):
             :services: name1, name2
             :service: name1 # no need to specify both services and service.
             :ignore: a comma separated list of services names to ignore
+            :docstring-replace: replace certain words in docstring
+
 
     """
     has_content = True
@@ -63,7 +73,8 @@ class ServiceDirective(Directive):
                    'app': directives.unchanged,
                    'service': directives.unchanged,
                    'services': convert_to_list,
-                   'ignore': convert_to_list}
+                   'ignore': convert_to_list,
+                   'docstring-replace': from_json_to_dict}
     domain = 'cornice'
     doc_field_types = []
 
@@ -141,11 +152,17 @@ class ServiceDirective(Directive):
             if method == 'HEAD':
                 # Skip head - this is essentially duplicating the get docs.
                 continue
+
             method_id = '%s-%s' % (service_id, method)
             method_node = nodes.section(ids=[method_id])
             method_node += nodes.title(text=method)
 
             docstring = self._resolve_obj_to_docstring(view, args)
+
+            for replace_key, replace_value in self.options.get(
+                'docstring-replace', {}
+            ).items():
+                docstring = docstring.replace(replace_key, replace_value)
 
             if 'schema' in args:
                 schema = args['schema']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,15 @@ class TestUtil(TestCase):
         self.assertEqual(res, b'<p><strong>simple render</strong></p>')
         self.assertEqual(rst2html(''), '')
 
+    def test_from_json_to_dict(self):
+        from cornice_sphinx import from_json_to_dict
+
+        argument = '{"user": "customer", "data": "information"}'
+        self.assertEqual(
+            from_json_to_dict(argument),
+            {'user': 'customer', 'data': 'information'},
+        )
+
 
 class TestServiceDirective(TestCase):
 
@@ -47,3 +56,9 @@ class TestServiceDirective(TestCase):
         # than str.__doc__.
         ret = self.directive.run()
         self.assertNotIn("str(object='') -> string", str(ret[0]))
+
+    def test_docstring_replace(self):
+        self.directive.options['docstring-replace'] = {
+            'user': 'customer', 'data': 'information'}
+        ret = self.directive.run()
+        self.assertIn('Returns the customer information', str(ret[0]))


### PR DESCRIPTION
Add `docstring-replace` which allows replacing values from the docsting.

You can use the new option like this:

```
.. cornice-autodoc::
  :modules: myapp.api
  :service: ping
  :docstring-replace: {
      "Foo Bar": "John Smith",
      "http://localhost:8080": "https://myapp.com"
    }
```

This will replace "Foo Bar" with "John Smith" and "http://localhost:8080"
with "https://myapp.com" from the docstring.